### PR TITLE
Add missing await to authn example

### DIFF
--- a/client/sandbox/vanilla-js-vite/src/main.ts
+++ b/client/sandbox/vanilla-js-vite/src/main.ts
@@ -111,7 +111,7 @@ function renderMagicCodePage(email: string) {
     e.preventDefault();
     const code = formEl.code.value;
     try {
-      db.auth.signInWithMagicCode({ email, code });
+      await db.auth.signInWithMagicCode({ email, code });
     } catch (e: any) {
       alert(`Uh oh! ${e.body?.message}`);
     }


### PR DESCRIPTION
The final step in the example of the vanilla authn logic was missing an `await` inside the async function verifying the login code.